### PR TITLE
fix(tools): generate CNAME pre-deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           make html
           touch build/html/.nojekyll
+          echo 'theaceae.jeremylt.org' > build/html/CNAME
       - name: Deploy documentation
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
The action pushes a clean slate to the branch which loses the CNAME file, causing GitHub to revert the custom domain.

Writing the CNAME file pre-deployment should fix this.